### PR TITLE
handles null data values in line chart

### DIFF
--- a/src/line/line.js
+++ b/src/line/line.js
@@ -38,6 +38,9 @@ this.lineChart = function(svg, settings, data) {
     chartInner = svg.select("g.margin-offset"),
     dataLayer = chartInner.select(".data"),
     line = d3.line()
+      .defined(function(d) {
+        if (d) return d;
+      })
       .x(function() {
         return x(mergedSettings.x.getValue.apply(mergedSettings, arguments));
       })


### PR DESCRIPTION
I added `.defined` to `d3.line` in case the line chart data has null values, e.g.

```
{
    "pop": {
        "keys": {
            "name": "date", 
            "values": ["2016-09", "2016-10", "2016-11", "2016-12"]
        }
        ,
        "world": [null, 62241, 64442, 160291],
        "city": [42241, 44442, 110291, 120291]
    }
}
```